### PR TITLE
Use only tsd.d.ts in typing references

### DIFF
--- a/src/generate_jsdoc.ts
+++ b/src/generate_jsdoc.ts
@@ -1,4 +1,4 @@
-/// <reference path="../typings/shelljs/shelljs.d.ts"/>
+/// <reference path="../typings/tsd.d.ts"/>
 import shell = require("shelljs");
 
 function generate_doc(module: string, path: string) {

--- a/src/generate_module.ts
+++ b/src/generate_module.ts
@@ -1,6 +1,4 @@
-/// <reference path="../typings/node/node.d.ts"/>
-/// <reference path="../typings/xml2js/xml2js.d.ts"/>
-/// <reference path="../typings/es6-promise/es6-promise.d.ts"/>
+/// <reference path="../typings/tsd.d.ts"/>
 import fs = require("fs");
 import xml2js = require("xml2js");
 import promise = require("es6-promise");


### PR DESCRIPTION
Actually, `tsd.d.ts` already contains all the references mentioned in `tsd.json` file  and installed through `tsd reinstall` command. So, no need to refer to them explicitly.
